### PR TITLE
fix typo and left for mobile-solid icon

### DIFF
--- a/css/icons/mobile-solid/before.css
+++ b/css/icons/mobile-solid/before.css
@@ -1,7 +1,7 @@
-.moon-solid.icon:before {
+.mobile-solid.icon:before {
   content: '';
   position: absolute;
-  left: 8px;
+  left: 1px;
   top: 3px;
   width: 8px;
   height: 10px;

--- a/scss/icons/mobile-solid/before.scss
+++ b/scss/icons/mobile-solid/before.scss
@@ -1,8 +1,8 @@
 @import '../../mixin';
-.moon-solid.icon {
+.mobile-solid.icon {
   &:before {
     @include pseudo();
-    left: 8px;
+    left: 1px;
     top: 3px;
     width: 8px;
     height: 10px;


### PR DESCRIPTION
- fixing typo
- fixing the value of `left`

